### PR TITLE
[#10] show code class if the code snippet is Java

### DIFF
--- a/src/book.json
+++ b/src/book.json
@@ -1,5 +1,5 @@
 {
-    "plugins": ["uml","-search"],
+    "plugins": ["uml","search","codeblock-filename"],
     "pluginsConfig": {
         "uml": {
             "format"  : "svg",

--- a/src/exercise3.md
+++ b/src/exercise3.md
@@ -10,7 +10,7 @@
   * 引数のアノテーションによると、`mailer` は null の可能性がない
   * 途中で `null` に出くわしたらに何もせず `return` している
 
-```java
+```java: Java
 public void sendMessageToClient(
     @Nullable Client client,
     @Nullable String message,

--- a/src/null_safe.md
+++ b/src/null_safe.md
@@ -19,14 +19,14 @@ Null 安全について記載します。
   * NullPointerException とは、中身が null な変数を参照すると起こる例外のこと
   * 割とありふれた例外だが、きっちり対処しようとすると若干手間
 
-```java
-// 以下は Java のコード
+* 以下、Java のコード例には「Java」と記載 (特に注釈がなければ Kotlin のコード例)
 
+```java: Java
 String s = null;
 s.toUpperCase(); // NullPointerException 発生
 ```
 
-```java
+```java: Java
 // 上記を回避する
 String s = null;
 if (s != null) { // null じゃないことを確認する
@@ -39,13 +39,12 @@ if (s != null) { // null じゃないことを確認する
   * その点だけ捉えると全ての変数について使う前に null チェックするのが妥当か…？
   * 文脈上、絶対に null でないことが確定しているような場合はチェックするべき？
 
-```java
+```java: Java
 String s = "hoge";
 // s は明らかに null じゃないのでチェックしないで良さそう
 
 String ss = Fuga(); // 文字列か null を返す関数だとしたら
 // ss は要チェック
-
 ```
 
 * チェックの要・不要を判断するのはプログラマ → 往々にして間違いが起こり得る
@@ -54,7 +53,7 @@ String ss = Fuga(); // 文字列か null を返す関数だとしたら
   * Android Java では `@NonNull` のようなアノテーションをメソッドに付与できる
   * しかし基本的に無力
 
-```java
+```java: Java
 // アノテーションによって本メソッドは null を返さないことを表明する
 @NonNull
 String Fuga() {


### PR DESCRIPTION
## Pull request for issue #10 

## 更新内容
* Java のコードスニペットと Kotlin のコードスニペットの見分けがつきやすくなるよう、コードスニペットが Java のものであるときは左肩に Java を補うように変更。
  * codeblock-filename プラグインを導入
  * this.json を book.json に変更。